### PR TITLE
Fixed markdown of triple backtick issue description

### DIFF
--- a/issues.py
+++ b/issues.py
@@ -24,7 +24,7 @@ class MultipleInlineIssue(_BaseIssue):
     
     
 class TripleBacktickCodeBlockIssue(_BaseIssue):
-    _description = "Use of triple backtick/ curlywhirly code blocks (` ``` ` ) or (`~~~`). These may not render correctly on all Reddit clients."
+    _description = "Use of triple backtick/ curlywhirly code blocks (```` ``` ```` or `~~~`). These may not render correctly on all Reddit clients."
     _pattern = re.compile(r'^(```(?:[^`]*?\n){3,}?```|~~~(?:[^~]*?\n){3,}?~~~)', re.MULTILINE)  # turns out reddit actually sometimes renders ```code``` correctly!
 
 


### PR DESCRIPTION
The description of the triple backtick issue had some erroneous markdown causing it to be displayed as:

![issue image](https://user-images.githubusercontent.com/94984768/161443997-8c7d615c-cf3b-4b66-9362-72157985e08c.png)

P.S. great project btw! I've been wanting to make something like this myself for a while but didn't get around to it